### PR TITLE
chore: Automatically open browser on dev server start

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --open",
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview"


### PR DESCRIPTION
Adds the --open flag to the 'dev' script, causing the browser to automatically open to the application when 'npm run dev' is executed.